### PR TITLE
Add MIT License to repository

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024 Sergei Nevedomski
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Mistral NER Fine-tuning
 
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+
 Fine-tune Mistral-7B for Named Entity Recognition (NER) on the CoNLL-2003 dataset using 8-bit quantization and LoRA for memory-efficient training.
 
 ## Features
@@ -40,7 +42,7 @@ mistral_ner/
 
 ```bash
 # Clone the repository
-git clone https://github.com/yourusername/mistral_ner.git
+git clone https://github.com/nevedomski/mistral_ner.git
 cd mistral_ner
 
 # Run automated setup (detects CUDA version)
@@ -213,9 +215,9 @@ If you use this code in your research, please cite:
 
 ```bibtex
 @software{mistral_ner,
-  author = {Your Name},
+  author = {Sergei Nevedomski},
   title = {Mistral NER: Efficient Fine-tuning for Named Entity Recognition},
   year = {2024},
-  url = {https://github.com/yourusername/mistral_ner}
+  url = {https://github.com/nevedomski/mistral_ner}
 }
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,19 @@ authors = [
     {name = "Sergei Nevedomski", email = "neviadomski@gmail.com"}
 ]
 readme = "README.md"
+license = {text = "MIT"}
 requires-python = ">=3.11,<3.12"
+classifiers = [
+    "Development Status :: 4 - Beta",
+    "Intended Audience :: Developers",
+    "Intended Audience :: Science/Research",
+    "License :: OSI Approved :: MIT License",
+    "Operating System :: OS Independent",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.11",
+    "Topic :: Scientific/Engineering :: Artificial Intelligence",
+    "Topic :: Text Processing :: Linguistic",
+]
 dependencies = [
     "accelerate>=1.7.0",
     "datasets>=3.6.0",


### PR DESCRIPTION
## Description
Adds proper MIT License to the repository to clarify usage rights, enable community contributions, and ensure legal compliance.

## Related Issues
- Linear: NER-11
- GitHub: #27

## ToDo List
- [x] Create LICENSE file with MIT License content
- [x] Add license badge to README.md
- [x] Update repository URLs and author information in README.md
- [x] Add license metadata to pyproject.toml with proper classifiers

## Checklist
- [x] LICENSE file created with MIT License text
- [x] README.md updated with license badge and corrected URLs
- [x] pyproject.toml updated with license field and classifiers
- [x] All changes are consistent across files

## Additional Notes
- MIT License chosen for maximum permissivity and compatibility with ML/AI ecosystem
- Added proper Python package classifiers for better discoverability
- Updated all placeholder URLs and author information