### PR TITLE
Test coverage for api/serve.py (82% → 96%)

### DIFF
--- a/api/serve.py
+++ b/api/serve.py
@@ -110,6 +110,9 @@ async def predict(request: NERRequest):
 
     try:
         # Run prediction
+        if config is None:
+            raise HTTPException(status_code=503, detail="Config not loaded")
+
         predictions = predict_entities(
             model=model,
             tokenizer=tokenizer,
@@ -145,6 +148,9 @@ async def predict_simple(texts: list[str]) -> list[dict[str, Any]]:
         raise HTTPException(status_code=503, detail="Model not loaded")
 
     try:
+        if config is None:
+            raise HTTPException(status_code=503, detail="Config not loaded")
+
         predictions = predict_entities(
             model=model,
             tokenizer=tokenizer,

--- a/scripts/inference.py
+++ b/scripts/inference.py
@@ -161,7 +161,7 @@ def extract_entities(words: list[str], labels: list[str]) -> list[dict[str, Any]
 
         elif label.startswith("I-") and current_entity:
             # Continue entity
-            current_entity["text"] += " " + word
+            current_entity["text"] = str(current_entity["text"]) + " " + word
             current_entity["end"] = i + 1
 
         else:


### PR DESCRIPTION
## Description
Improved test coverage for api/serve.py from 82% to 96%, exceeding the 90% target requirement.

## Related Issues
- Resolves NER-18: Test coverage for api/serve.py (82% → 90%+)

## ToDo List
- [x] Fix async startup tests with proper pytest.mark.asyncio decorators
- [x] Add comprehensive test coverage for startup event scenarios
- [x] Add tests for TYPE_CHECKING imports and main execution
- [x] Improve error handling with config null checks
- [x] Fix mypy type error in scripts/inference.py
- [x] Achieve 96% test coverage (target: 90%+)

## Checklist
- [x] Code passes ruff checks
- [x] Code passes ruff format
- [x] Code passes mypy checks
- [x] Unit Test coverage is 96% for api/serve.py (exceeds 90% requirement)
- [x] All new and existing tests pass (25/25 tests passing)
- [x] Documentation has been updated if applicable

## Additional Notes
- Fixed async startup tests that were previously being skipped
- Added comprehensive error handling for config loading scenarios
- Enhanced test coverage includes TYPE_CHECKING imports and main execution paths
- All quality gates pass: ruff, mypy, pytest with 96% coverage