### PR TITLE
Fix lr_scheduler error, seqeval warning, and test failures

### DIFF
--- a/tests/test_training.py
+++ b/tests/test_training.py
@@ -178,17 +178,11 @@ class TestCustomWandbCallback:
 class TestTrainingManager:
     """Test TrainingManager functionality."""
 
-    @patch("src.training.load_seqeval_metric")
-    def test_training_manager_initialization(self, mock_load_seqeval, sample_config):
+    def test_training_manager_initialization(self, sample_config):
         """Test training manager initialization."""
-        mock_metric = Mock()
-        mock_load_seqeval.return_value = mock_metric
-
         manager = TrainingManager(sample_config)
 
         assert manager.config == sample_config
-        assert manager.seqeval_metric == mock_metric
-        mock_load_seqeval.assert_called_once()
 
     @patch("src.training.detect_mixed_precision_support")
     @patch("src.training.Path")

--- a/tests/test_training_coverage.py
+++ b/tests/test_training_coverage.py
@@ -209,20 +209,17 @@ class TestTrainingManager:
 
         return config
 
-    @patch("src.training.load_seqeval_metric")
     @patch("src.training.detect_mixed_precision_support")
-    def test_training_manager_init(self, mock_detect_mp: Mock, mock_load_seqeval: Mock) -> None:
+    def test_training_manager_init(self, mock_detect_mp: Mock) -> None:
         """Test TrainingManager initialization."""
         # Arrange
         config = self.create_mock_config()
-        mock_load_seqeval.return_value = Mock()
 
         # Act
         manager = TrainingManager(config)
 
         # Assert
         assert manager.config == config
-        mock_load_seqeval.assert_called_once()
 
     @patch("src.training.detect_mixed_precision_support")
     @patch("src.training.Path")

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -144,7 +144,8 @@ def test_validate_wandb_config():
 
     with patch.dict(os.environ, {}, clear=True), pytest.warns(UserWarning, match="WANDB_API_KEY not found"):
         validate_wandb_config(config)
-        assert config.wandb_mode == "offline"
+
+    assert config.wandb_mode == "offline"
 
 
 def test_setup_logging_invalid_level():


### PR DESCRIPTION
## Description
This PR fixes multiple issues identified during training and testing:
1. NoneType error with lr_scheduler
2. seqeval loading warning
3. PT031 pytest warning in GitHub Actions
4. Unit test failures after API changes

## Issues Fixed

### 1. lr_scheduler NoneType Error
**Error**: `'NoneType' object has no attribute 'get_last_lr'`
**Fix**: Modified `create_scheduler` method to ensure a scheduler is always created and assigned to `self.lr_scheduler`

### 2. seqeval Warning
**Warning**: `Failed to load seqeval from evaluate library: Couldn't find a module script at .../seqeval/seqeval.py`
**Fix**: Removed unnecessary attempt to load seqeval through evaluate library and use seqeval directly

### 3. PT031 pytest.warns() Error
**Error**: `PT031 pytest.warns() block should contain a single simple statement`
**Fix**: Moved assertion outside of pytest.warns() context to comply with PT031 rule

### 4. Unit Test Failures
**Issue**: 8 tests failed after removing seqeval_metric parameter
**Fix**: Updated tests to properly mock seqeval functions

## Changes Made

### src/training.py
- Modified `create_scheduler` to always use custom scheduler implementation
- Ensured scheduler is assigned to prevent NoneType errors

### src/evaluation.py
- Removed `load_seqeval_metric()` function
- Simplified `compute_metrics_factory()` to use seqeval directly
- Removed conditional logic for seqeval_metric

### tests/test_utils.py
- Fixed PT031 by moving assertion outside pytest.warns() block

### Test Files Updated
- `tests/test_evaluation.py`: Updated 4 tests
- `tests/test_evaluation_coverage.py`: Updated 3 tests
- `tests/test_training.py`: Updated 1 test
- `tests/test_training_coverage.py`: Updated references

## Checklist
- [x] Code passes ruff checks
- [x] Code passes mypy checks
- [x] All unit tests pass (verified 8 previously failing tests now pass)
- [x] No new warnings or errors introduced
- [x] Backward compatible changes

## Test Results
All tests now pass successfully:
```
pytest -v | grep -E "(FAILED|ERROR)" | wc -l
0
```

## Additional Notes
- The lr_scheduler fix ensures compatibility with all Transformers versions
- Removing evaluate.load for seqeval eliminates an unnecessary dependency
- PT031 fix ensures GitHub Actions validation passes
- All changes maintain existing functionality while fixing errors