### PR TITLE
fix: resolve broken links in MkDocs documentation

### DIFF
--- a/docs/api-reference/overview.md
+++ b/docs/api-reference/overview.md
@@ -179,7 +179,7 @@ with HyperparameterOptimizer(config.hyperopt) as optimizer:
 
 ## REST API
 
-See [REST API Reference](rest-api.md) for HTTP endpoint documentation.
+<!-- See [REST API Reference](rest-api.md) for HTTP endpoint documentation. -->
 
 ## CLI Reference
 
@@ -274,6 +274,6 @@ except Exception as e:
 
 ## Next Steps
 
-- Explore the [Python API](python-api.md) in detail
-- Learn about the [REST API](rest-api.md)
+<!-- - Explore the [Python API](python-api.md) in detail -->
+<!-- - Learn about the [REST API](rest-api.md) -->
 - See [examples](https://github.com/nevedomski/mistral_ner/tree/main/examples) for real-world usage

--- a/docs/index.md
+++ b/docs/index.md
@@ -77,9 +77,11 @@ python scripts/inference.py --text "Apple Inc. CEO Tim Cook announced new produc
 - **[Hyperparameter Tuning](user-guide/hyperparameter-tuning.md)** - Optimize model performance
 
 ### For Advanced Users
+<!-- Coming soon:
 - **[Model Architecture](advanced/model-architecture.md)** - Deep dive into Mistral-7B + LoRA
 - **[Performance Tuning](advanced/performance-tuning.md)** - Squeeze out maximum performance
 - **[Deployment Guide](advanced/deployment.md)** - Deploy to production
+-->
 
 ## 🏆 Performance Highlights
 


### PR DESCRIPTION
## Description
This PR fixes broken links in the MkDocs documentation that were causing the deployment to fail in strict mode.

## Related Issues
Fixes MkDocs deployment failures due to broken links.

## Changes
- Commented out references to non-existent advanced documentation pages in `index.md`:
  - `advanced/model-architecture.md`
  - `advanced/performance-tuning.md`
  - `advanced/deployment.md`
- Commented out references to non-existent API reference pages in `api-reference/overview.md`:
  - `rest-api.md`
  - `python-api.md`

## Testing
Verified that `mkdocs build --strict` now completes successfully without warnings about broken links.

## Checklist
- [x] Documentation builds successfully with `mkdocs build --strict`
- [x] No broken links in the documentation
- [x] Changes are minimal and preserve future expansion capability

## Additional Notes
- The commented sections can be uncommented when the referenced documentation pages are created
- This is a quick fix to get the documentation deployment working again